### PR TITLE
fix: fix unsupported sql query and group queries into one transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd server/LiventCord
 ```
 Create database
 ```bash
-dotnet ef migrations add InitialCreate
+dotnet ef migrations add InitialCreate --context AppDbContext
 ```
 ```bash
 dotnet run
@@ -43,7 +43,7 @@ dotnet run
 ```bash
 cd web
 pnpm install
-mv .env.example .env
+cp .env.example .env
 pnpm run dev
 ```
 Dev server runs at `http://localhost:3000`.

--- a/server/LiventCord/Program.cs
+++ b/server/LiventCord/Program.cs
@@ -226,7 +226,11 @@ Log.Logger = new LoggerConfiguration()
 
 app.UseMiddleware<RequestCountingMiddleware>();
 app.UseSerilogRequestLogging();
-app.UseHttpsRedirection();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseRouting();
 app.UseCors("AllowSpecificOrigin");

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,12 +1,13 @@
+import path from "path";
 import { defineConfig, loadEnv } from "vite";
 import vue from "@vitejs/plugin-vue";
 import eslintPlugin from "vite-plugin-eslint";
 import autoprefixer from "autoprefixer";
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd());
+  const env = loadEnv(mode, path.resolve(__dirname));
 
-  const proxyTarget = "http://localhost:5005";
+  const proxyTarget = env.VITE_BACKEND_URL || "http://localhost:5005";
   const proxyPaths = ["/api", "/profiles", "/guilds", "/attachments", "/auth"];
   const proxyConfig = proxyPaths.reduce(
     (acc, path) => {
@@ -20,6 +21,7 @@ export default defineConfig(({ mode }) => {
     root: "./src",
     publicDir: "../public",
     base: "/",
+    envDir: path.resolve(__dirname),
     plugins: [vue(), eslintPlugin({ emitWarning: false })],
     css: {
       postcss: {


### PR DESCRIPTION
### Error logs:
```
[20:48:57 ERR] [LiventCord.Helpers.AppLogicService] An error occurred while fetching the initial data.
System.InvalidOperationException: Translating this query requires the SQL APPLY operation, which is not supported on SQLite.
   at Microsoft.EntityFrameworkCore.Sqlite.Query.Internal.SqliteQueryTranslationPostprocessor.ApplyValidatingVisitor.VisitExtension(Expression extensionExpression)
   at Microsoft.EntityFrameworkCore.Sqlite.Query.Internal.SqliteQueryTranslationPostprocessor.ApplyValidatingVisitor.VisitExtension(Expression extensionExpression)
   at Microsoft.EntityFrameworkCore.Query.QueryCompilationContext.CreateQueryExecutor[TResult](Expression query)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.<>c__DisplayClass12_0`1.<ExecuteAsync>b__0()
   at Microsoft.EntityFrameworkCore.Query.Internal.CompiledQueryCache.GetOrAddQuery[TResult](Object cacheKey, Func`1 compiler)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.ExecuteAsync[TResult](Expression query, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1.GetAsyncEnumerator(CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.GetAsyncEnumerator()
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)
   at LiventCord.Controllers.FriendController.GetFriends(String userId) in C:\Users\Jam\Desktop\projects\LiventCord\server\LiventCord\Controllers\Friend\FriendController.cs:line 330
   at LiventCord.Helpers.AppLogicService.HandleInitRequest(HttpContext context) in C:\Users\Jam\Desktop\projects\LiventCord\server\LiventCord\Helpers\AppLogic.cs:line 130
   ```
   
   ### Steps to reproduce:
   1- Create a new account
   2- log in normally, the backend will report these errors